### PR TITLE
docs: add more detailed explanation of bootstrap cmd

### DIFF
--- a/lang/de.po
+++ b/lang/de.po
@@ -64,6 +64,10 @@ msgstr "Fehler mit vollem Backtrace ausgeben"
 msgid "set's up a new instance"
 msgstr "richtet eine neue Instanz ein"
 
+#: /home/hendrik/code/ascii/asciii/src/bin/cli/app.rs:27
+msgid "set's up a new instance. Clones the repository and initializes the global config file."
+msgstr "richtet eine neue Instanz ein. Klont das Repository und initialisiert die globale Konfigurationsdatei."
+
 #: /home/hendrik/code/ascii/asciii/src/bin/cli/app.rs:28
 msgid "Remote repository"
 msgstr "Remote Repository"

--- a/src/bin/cli/app.rs
+++ b/src/bin/cli/app.rs
@@ -24,6 +24,7 @@ pub fn with_cli<F> (app_handler:F) where F: Fn(App<'_, '_>) {
             .subcommand(SubCommand::with_name("bootstrap")
                         .aliases(&["boot", "clone"])
                         .about(lformat!("set's up a new instance").as_ref())
+                        .long_about(lformat!("set's up a new instance. Clones the repository and initializes the global config file.").as_ref())
                         .arg(Arg::with_name("repo")
                              .help(lformat!("Remote repository").as_ref())
                              .required(true))


### PR DESCRIPTION
It wasn't really clear whether "bootstrap" initializes an entirely new repository or just clones an existing one. The change should make this clear.