### PR TITLE
Add month to long invoice number

### DIFF
--- a/src/project/spec_yaml.rs
+++ b/src/project/spec_yaml.rs
@@ -418,8 +418,10 @@ impl<'a> Invoicable for Invoice<'a> {
 
     fn number_long_str(&self) -> Option<String> {
         let year = self.date().ok()?.year();
+        let month = self.date().ok()?.month();
+
         // TODO: Length or format should be a setting
-        self.number().ok().map(|n| format!("R{}-{:03}", year, n))
+        self.number().ok().map(|n| format!("R{}-{:02}-{:03}", year, month, n))
     }
 
     fn official(&self) -> FieldResult<String> {


### PR DESCRIPTION
There have been mistakes with duplicate invoice numbers due to user errors. As an safety net, we would like to include the month of the invoice to its number.